### PR TITLE
Добавить тип UtcDatetime (#9)

### DIFF
--- a/tests/test_shared/test_types.py
+++ b/tests/test_shared/test_types.py
@@ -2,4 +2,5 @@ from __future__ import annotations
 
 from wlss.shared.types import (
     Id,  # noqa: F401
+    UtcDatetime,  # noqa: F401
 )

--- a/wlss/shared/types.py
+++ b/wlss/shared/types.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
-from wlss.core.types import PositiveInt
+from datetime import timezone
+
+from wlss.core.types import AwareDatetime, PositiveInt
 
 
 class Id(PositiveInt):
     ...
+
+
+class UtcDatetime(AwareDatetime):
+    TIMEZONE = timezone.utc


### PR DESCRIPTION
 Т.к. на бэке мы планируем использовать время только в UTC, необходимо добавить этот тип в wlss/shared/types.py

---

Заодно так же была переименована директория для тестов test_common -> test_shared чтобы название пакета с тестами матчилось с пакетом wlss/shared