### PR TITLE
Добавить реализацию __eq__ и __hash__ (#13)

### DIFF
--- a/tests/test_core/test_types.py
+++ b/tests/test_core/test_types.py
@@ -55,6 +55,23 @@ class Test_Int:  # noqa: N801
         assert exc_info.type is ValidationError
         assert exc_info.value.args == ("VALUE_MAX should not be less than VALUE_MIN.", )
 
+    @staticmethod
+    def test_when_object_compared_to_another_object():
+        assert Int(42) == Int(42)
+
+    @staticmethod
+    def test_when_object_compared_to_another_object_of_different_class():
+        class FooInt(Int):
+            ...
+        class BarInt(Int):
+            ...
+
+        assert FooInt(42) != BarInt(42)
+
+    @staticmethod
+    def test_when_object_is_hashed():
+        assert hash(Int(42)) == hash(42)
+
 
     @staticmethod
     def test_when_WLSS_LIB_TRACEBACK_is_not_set(tmp_path):

--- a/wlss/core/types.py
+++ b/wlss/core/types.py
@@ -41,6 +41,16 @@ class Type(ABC, Generic[T]):
     def value(self: Self) -> T:
         return self._value
 
+    @override
+    def __eq__(self: Self, other: object) -> bool:
+        if isinstance(other, self.__class__):
+            return other.value == self.value
+        return NotImplemented
+
+    @override
+    def __hash__(self: Self) -> int:
+        return hash(self.value)
+
 
 
 class Int(Type[int]):


### PR DESCRIPTION
Чтобы наши кастомные типы можно было сравнивать и, что немаловажно, использовать в тестах для проверок значений, необходимо реализовать метод __eq__ чтобы объекты наших типов как минимум удовлетворяли условию простейшего равенства, например:
```python
assert Int(42) == Int(42)
```

Согласно [доке](https://docs.python.org/3/reference/datamodel.html#object.__hash__) для объектов, в которых переопределён метод __eq__, необходимо переопределить так же и метод __hash__, чтобы они были хэшируемыми и могли использоваться например в качестве ключей словаря. Поскольку (судя по всему) алхимия внутри себя использует значения как ключи словаря, то для наших объектов необходимо определить этот метод, чтобы всё работало корректно. (возможно отсутствие хэширования помешало бы нам ещё где-нибудь, но кажется нет большого смысла это выяснять сейчас, если мы уже знаем, что как минимум для одного случая нам всё-таки надо реализовать этот метод)

В рамках этой задачи необходимо добавить __eq__ и __hash__ в наши кастомные типы.