### PR TITLE
Добавить ограничение длины имени файла (#18)

### DIFF
--- a/tests/test_file/test_types.py
+++ b/tests/test_file/test_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 from wlss.file.types import (
+    FileName,  # noqa: F401
     FileSize,  # noqa: F401
 )

--- a/wlss/file/types.py
+++ b/wlss/file/types.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
-from wlss.core.types import Int, PositiveInt
+from wlss.core.types import Int, PositiveInt, Str
 from wlss.file.constants import BYTE, MEGABYTE
+
+
+class FileName(Str):
+    LENGTH_MIN = PositiveInt(1)
+    LENGTH_MAX = PositiveInt(256)
 
 
 class FileSize(PositiveInt):


### PR DESCRIPTION
В рамках этой задачи необходимо добавить кастомный тип для имени файла - `FileName`, который бы (пока что) ограничивал длину имени файла, т.к. мы не хотим, чтобы пользователь мог загружать файлы с именем размером 100мб и таким образом перегружать систему.