### PR TITLE
Поправить REGEXP для WishDescription и ProfileDescription (#20)

### DIFF
--- a/wlss/profile/types.py
+++ b/wlss/profile/types.py
@@ -8,7 +8,7 @@ from wlss.core.types import PositiveInt, Str
 class ProfileDescription(Str):
     LENGTH_MAX = PositiveInt(1000)
     LENGTH_MIN = PositiveInt(1)
-    REGEXP = re.compile(r".{1,1000}")
+    REGEXP = re.compile(r".{1,1000}", flags=re.DOTALL)
 
 
 class ProfileName(Str):

--- a/wlss/wish/types.py
+++ b/wlss/wish/types.py
@@ -8,7 +8,7 @@ from wlss.core.types import PositiveInt, Str
 class WishDescription(Str):
     LENGTH_MAX = PositiveInt(10_000)
     LENGTH_MIN = PositiveInt(1)
-    REGEXP = re.compile(r".*")
+    REGEXP = re.compile(r".*", flags=re.DOTALL)
 
 
 class WishTitle(Str):


### PR DESCRIPTION
На данный момент регулярка `r".*"` не матчит текст в котором содержатся переводы строк, например `"hello\nworld"`. Поскольку описания желания и профиля могут быть многострочными, необходимо исправить это.

В рамках этой задачи необходимо добавить флаг `re.DOTALL` для многострочных регулярок, который сделает так, чтобы `.` матчила не только простые символы, но и переводы строки.